### PR TITLE
Fix incompatibilities with php8

### DIFF
--- a/ludo_blacklist_ip_Check_IP_Module.php
+++ b/ludo_blacklist_ip_Check_IP_Module.php
@@ -58,14 +58,14 @@ function ludo_blacklist_ip_Check_IP ( &$IP ) {
 			return false ;
 		}
 	}
-	$IP = implode ( $IPs , "." );
+	$IP = implode ( ".", $IPs );
 	return true;
 }
 
 function ludo_blacklist_ip_IP_Trim ( $IP ) {
 	// Input : array of IP address with strings 
 	// Output : array of the IP address with integer
-	return 0+ltrim ( trim ( $IP ) , "0" ) ;
+	return (int) ltrim ( trim ( $IP ) , "0" ) ;
 }
 
 function ludo_blacklist_ip_Check_Mask ( $Mask ) {


### PR DESCRIPTION
Fix two small incompatibilities with PHP >= 8.0

* Passing parameters to implode() in reverse order is deprecated, use implode($glue, $parts) instead of implode($parts, $glue)
* Using int+string to cast a string to an int no longer supported, must use (int)